### PR TITLE
Inlined bluebird reference link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ in Node.js as well as the browser.
 
 It requires a Promise implementation to work. If you're on Node.js v4 or
 later, you should be fine. Otherwise, you'll also need to install
-[bluebird] (or [rsvp], [when], or [q.js]).
+[bluebird](https://github.com/petkaantonov/bluebird) (or [rsvp], [when], or [q.js]).
 
-[bluebird]: https://github.com/petkaantonov/bluebird
 [rsvp]: https://www.npmjs.com/package/rsvp
 [q.js]: https://github.com/kriskowal/q
 [when]: https://github.com/cujojs/when


### PR DESCRIPTION
I'm wondering why the link doesn't work until I checked the `README.md` file.

![bluebird](https://cloud.githubusercontent.com/assets/2811885/12257677/7838f0f2-b943-11e5-8787-f6e8bf9a3c2b.gif)

Seems like the parenthesis next to the `[bluebird]` link text is being considered as the reference link even though there's a space that separates it. (TIL about that)

Not sure if you like the inline-way, just leaving this here for the fix. Thanks! :blush: 
