### PR TITLE
Allow cron jobs whose next execution is more than 25 days away

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var CronConverter = require('cron-converter')
 var moment = require('moment-timezone')
 var ms = require('pretty-ms')
 var Promise = require('any-promise')
+var lt = require('long-timeout')
 var debug = function () {}
 
 /*
@@ -45,8 +46,8 @@ function cron (options, fn) {
     debug(name + ': next run in ' + ms(delta) +
       ' at ' + future.format('llll Z'))
 
-    if (timer) clearTimeout(timer)
-    timer = setTimeout(run, delta)
+    if (timer) lt.clearTimeout(timer)
+    timer = lt.setTimeout(run, delta)
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "any-promise": "0.1.0",
     "cron-converter": "0.0.8",
+    "long-timeout": "^0.1.1",
     "moment-timezone": "0.5.0",
     "pretty-ms": "2.1.0"
   },


### PR DESCRIPTION
I ran afoul of the 2147483647ms limit of `setTimeout()` while using `cron-scheduler`